### PR TITLE
makes scanning doubles independent on host locale

### DIFF
--- a/src/starfish/core/boundaries/Spline.java
+++ b/src/starfish/core/boundaries/Spline.java
@@ -9,6 +9,7 @@ package starfish.core.boundaries;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Scanner;
 import starfish.core.boundaries.Boundary.BoundaryType;
 import starfish.core.common.Constants;
@@ -130,6 +131,7 @@ public class Spline
 
 	Scanner sc = new Scanner(path);
 	sc.useDelimiter("[,\\s\\n\\t]+");
+	sc.useLocale(Locale.English)
 
 	/*need [0,0,1] so we can apply translation via transformation matrix*/
 	double x1[]={0,0,1};


### PR DESCRIPTION
A friend of mine asked me to help him debug starfish, already suspecting the locale as a factor, since it died when calling `sc.nextDouble()`.

Changing the locale in the operating system did not help, however, only using a commandline option, when calling the jar helped.

Since the doubles will (hopefully) always be in the US format it is safe to configure the scanner inside the program as such, without consulting the users locale.

The only way this would fail is, if the user would insist on writing a boundaries file with their local way of representing doubles, but then that's their problem, in my opinion.

**important**
This is not the code I used to fix it, when my friend asked me, so I didn't run and test this code, but I'm fairly certain it shouldn't make any problems. Please test it on your end, though. 